### PR TITLE
Replace 'kubectl' by 'dcos kubernetes' in kubectl output if --help is detected

### DIFF
--- a/dcos_kubernetes/cli.py
+++ b/dcos_kubernetes/cli.py
@@ -22,6 +22,13 @@ def kubectl_binary_path_and_url():
     else:
         return (None, None)
 
+def read_in_chunks(file_object, chunk_size=1024):
+    while True:
+        data = file_object.read(chunk_size)
+        if not data:
+            break
+        yield data
+
 def download_kubectl(url, kubectl_path):
     import tarfile
 
@@ -30,10 +37,10 @@ def download_kubectl(url, kubectl_path):
             # download tar.gz
             print "Download kubectl from " + url
             from clint.textui import progress
-            import requests
-            r = requests.get(url, stream=True)
-            total_length = int(r.headers.get("content-length"))
-            for chunk in progress.bar(r.iter_content(chunk_size=1024), expected_size=(total_length/1024) + 1):
+            import urllib2
+            f = urllib2.urlopen(url)
+            total_length = int(f.info().getheader("Content-Length"))
+            for chunk in progress.bar(read_in_chunks(f), expected_size=(total_length/1024) + 1):
                 if chunk:
                     os.write(fd, chunk)
 


### PR DESCRIPTION
```
dcos kubernetes controls the Kubernetes cluster manager.

Find more information at https://github.com/GoogleCloudPlatform/kubernetes.

Usage: 
  dcos kubernetes [flags]
  dcos kubernetes [command]

Available Commands: 
  get           Display one or many resources
  describe      Show details of a specific resource
  create        Create a resource by filename or stdin
  update        Update a resource by filename or stdin.
  delete        Delete a resource by filename, stdin, or resource and ID.
  namespace     SUPERCEDED: Set and view the current Kubernetes namespace
  log           Print the logs for a container in a pod.
  rollingupdate Perform a rolling update of the given ReplicationController.
  resize        Set a new size for a Replication Controller.
  exec          Execute a command in a container.
  port-forward  Forward one or more local ports to a pod.
  proxy         Run a proxy to the Kubernetes API server
  run-container Run a particular image on the cluster.
  stop          Gracefully shut down a resource by id or filename.
  expose        Take a replicated application and expose it as Kubernetes Service
  label         Update the labels on a resource
  config        config modifies .kubeconfig files
  clusterinfo   Display cluster info
  apiversions   Print available API versions.
  version       Print the client and server version information.
  help          Help about any command

Flags:
      --alsologtostderr=false: log to standard error as well as files
      --api-version="": The API version to use when talking to the server
  -a, --auth-path="": Path to the auth info file. If missing, prompt the user. Only used if using https.
      --certificate-authority="": Path to a cert. file for the certificate authority.
      --client-certificate="": Path to a client key file for TLS.
      --client-key="": Path to a client key file for TLS.
      --cluster="": The name of the kubeconfig cluster to use
      --context="": The name of the kubeconfig context to use
  -h, --help=false: help for dcos kubernetes
      --insecure-skip-tls-verify=false: If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
      --kubeconfig="": Path to the kubeconfig file to use for CLI requests.
      --log_backtrace_at=:0: when logging hits line file:N, emit a stack trace
      --log_dir=: If non-empty, write log files in this directory
      --log_flush_frequency=5s: Maximum number of seconds between log flushes
      --logtostderr=true: log to standard error instead of files
      --match-server-version=false: Require server version to match client version
      --namespace="": If present, the namespace scope for this CLI request.
      --password="": Password for basic authentication to the API server.
  -s, --server="": The address and port of the Kubernetes API server
      --stderrthreshold=2: logs at or above this threshold go to stderr
      --token="": Bearer token for authentication to the API server.
      --user="": The name of the kubeconfig user to use
      --username="": Username for basic authentication to the API server.
      --v=0: log level for V logs
      --validate=false: If true, use a schema to validate the input before sending it
      --vmodule=: comma-separated list of pattern=N settings for file-filtered logging


Use "dcos kubernetes help [command]" for more information about a command.
```
